### PR TITLE
mv config files to /etc/sysconfig/s3nd dir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,4 +32,12 @@ class s3nd (
       }
     }
   }
+
+  file { '/etc/sysconfig/s3nd':
+    ensure  => directory,
+    mode    => '0700',
+    purge   => true,
+    recurse => true,
+    force   => true,
+  }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -31,7 +31,7 @@ define s3nd::instance (
     'AWS_SECRET_ACCESS_KEY' => $aws_secret_access_key.unwrap,
   } + $s3nd::env + $env
 
-  file { "/etc/sysconfig/s3nd-${name}":
+  file { "/etc/sysconfig/s3nd/s3nd-${name}":
     ensure    => file,
     show_diff => false,  # don't leak secrets in the logs
     mode      => '0600',  # only root should be able to read the secrets
@@ -61,7 +61,7 @@ define s3nd::instance (
     },
     container_entry => {
       'EnvironmentFile' => [
-        "/etc/sysconfig/s3nd-${name}",
+        "/etc/sysconfig/s3nd/s3nd-${name}",
       ],
       'Image'           => $_image,
       'Network'         => 'host',

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -10,8 +10,15 @@ describe 's3nd' do
 
     it_behaves_like 'an idempotent resource'
 
+    describe file('/etc/sysconfig/s3nd') do
+      it { is_expected.to be_directory }
+      it { is_expected.to be_mode '700' }
+      it { is_expected.to be_owned_by 'root' }
+      it { is_expected.to be_grouped_into 'root' }
+    end
+
     context 'instance foo' do
-      describe file('/etc/sysconfig/s3nd-foo') do
+      describe file('/etc/sysconfig/s3nd/s3nd-foo') do
         it { is_expected.to be_file }
         it { is_expected.to be_mode '600' }
         it { is_expected.to contain 'S3ND_PORT=15556' }
@@ -43,7 +50,7 @@ describe 's3nd' do
     end
 
     context 'instance bar' do
-      describe file('/etc/sysconfig/s3nd-bar') do
+      describe file('/etc/sysconfig/s3nd/s3nd-bar') do
         it { is_expected.to be_file }
         it { is_expected.to be_mode '600' }
         it { is_expected.to contain 'S3ND_PORT=15557' }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -26,7 +26,17 @@ describe 's3nd::instance' do
       it { is_expected.to compile.with_all_deps }
 
       it do
-        is_expected.to contain_file("/etc/sysconfig/s3nd-#{title}").with(
+        is_expected.to contain_file('/etc/sysconfig/s3nd').with(
+          ensure: 'directory',
+          mode: '0700',
+          purge: true,
+          recurse: true,
+          force: true
+        )
+      end
+
+      it do
+        is_expected.to contain_file("/etc/sysconfig/s3nd/s3nd-#{title}").with(
           ensure: 'file',
           show_diff: false,
           mode: '0600',
@@ -35,14 +45,14 @@ describe 's3nd::instance' do
       end
 
       it do
-        is_expected.to contain_file("/etc/sysconfig/s3nd-#{title}").
+        is_expected.to contain_file("/etc/sysconfig/s3nd/s3nd-#{title}").
           that_notifies("Quadlets::Quadlet[s3nd-#{title}.container]")
       end
 
       it do
         is_expected.to contain_quadlets__quadlet("s3nd-#{title}.container").with(
           container_entry: {
-            'EnvironmentFile' => ["/etc/sysconfig/s3nd-#{title}"],
+            'EnvironmentFile' => ["/etc/sysconfig/s3nd/s3nd-#{title}"],
             'Image'           => 'ghcr.io/lsst-dm/s3nd:main',
             'Network'         => 'host',
             'Volume'          => [
@@ -65,7 +75,7 @@ describe 's3nd::instance' do
         end
 
         it do
-          is_expected.to contain_file("/etc/sysconfig/s3nd-#{title}").with(
+          is_expected.to contain_file("/etc/sysconfig/s3nd/s3nd-#{title}").with(
             content: %r{FOO=BAR}
           )
         end
@@ -83,7 +93,7 @@ describe 's3nd::instance' do
         end
 
         it do
-          is_expected.to contain_file("/etc/sysconfig/s3nd-#{title}").with(
+          is_expected.to contain_file("/etc/sysconfig/s3nd/s3nd-#{title}").with(
             content: %r{BAZ=QUX}
           )
         end
@@ -109,13 +119,13 @@ describe 's3nd::instance' do
         end
 
         it do
-          is_expected.to contain_file("/etc/sysconfig/s3nd-#{title}").with(
+          is_expected.to contain_file("/etc/sysconfig/s3nd/s3nd-#{title}").with(
             content: %r{BAZ=QUX}
           )
         end
 
         it do
-          is_expected.to contain_file("/etc/sysconfig/s3nd-#{title}").with(
+          is_expected.to contain_file("/etc/sysconfig/s3nd/s3nd-#{title}").with(
             content: %r{FOO=BAR}
           )
         end


### PR DESCRIPTION
A dedicated s3nd specific dir is used so that purging may be enabled to automatically cleanup config files which contain secrets after an s3nd instance is removed.