### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v1.2.1](https://github.com/lsst-it/puppet-s3nd/tree/v1.2.1) (2025-10-01)
+
+[Full Changelog](https://github.com/lsst-it/puppet-s3nd/compare/v1.2.0...v1.2.1)
+
+**Breaking changes:**
+
+- drop puppet7 support [\#6](https://github.com/lsst-it/puppet-s3nd/pull/6) ([jhoblitt](https://github.com/jhoblitt))
+
+## [v1.2.0](https://github.com/lsst-it/puppet-s3nd/tree/v1.2.0) (2025-09-26)
+
+[Full Changelog](https://github.com/lsst-it/puppet-s3nd/compare/v1.1.0...v1.2.0)
+
+**Implemented enhancements:**
+
+- \(metadata.json\) Bump quadlets to include 2.x.x [\#4](https://github.com/lsst-it/puppet-s3nd/pull/4) ([badenerb](https://github.com/badenerb))
+
 ## [v1.1.0](https://github.com/lsst-it/puppet-s3nd/tree/v1.1.0) (2025-08-04)
 
 [Full Changelog](https://github.com/lsst-it/puppet-s3nd/compare/v1.0.0...v1.1.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lsst-s3nd",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "author": "AURA/LSST/Rubin Observatory",
   "summary": "S3 Nexus Deliverator",
   "license": "Apache-2.0",


### PR DESCRIPTION
Automated release-prep through https://github.com/voxpupuli/gha-puppet/ from commit d4d4c494949606b106c2ba59bc08712f041efafc.
Checkout the [module release instructions](https://voxpupuli.org/docs/releasing_version/).